### PR TITLE
Fix NaN uniformity in txt_new

### DIFF
--- a/txt_new.py
+++ b/txt_new.py
@@ -116,8 +116,13 @@ def evaluate_fitness(
             if intensities_up:
                 mean_up = np.mean(intensities_up)
                 std_up = np.std(intensities_up)
-                cv_up_angle = std_up / mean_up
-                uniformity_angle = 1/ (1 + cv_up_angle) 
+                if mean_up == 0:
+                    cv_up_angle = np.nan
+                else:
+                    cv_up_angle = std_up / mean_up
+                uniformity_angle = 1 / (1 + cv_up_angle)
+                if not np.isfinite(uniformity_angle):
+                    uniformity_angle = 0.0
             else:
                 uniformity_angle = 0.0
 
@@ -152,8 +157,10 @@ def evaluate_fitness(
     # fitness = efficiency * (1 / (1 + process_score))
     # return fitness, efficiency, process_score, efficiencies_per_angle
     if uniformities_per_angle:
-        uniformity = float(np.mean(uniformities_per_angle))
+        uniformity = float(np.nanmean(uniformities_per_angle))
     else:
+        uniformity = 0.0
+    if not np.isfinite(uniformity):
         uniformity = 0.0
 
     # === Step 1: 設定標準化上下限 ===


### PR DESCRIPTION
## Summary
- guard against divide by zero when calculating uniformity
- use `np.nanmean` when averaging uniformities
- fall back to zero when uniformity results in NaN

## Testing
- `python -m py_compile txt_new.py`

------
https://chatgpt.com/codex/tasks/task_e_685409053c6083279603a9eb04c6334c