### PR TITLE
Expose uniformity flag

### DIFF
--- a/ES2.py
+++ b/ES2.py
@@ -25,6 +25,9 @@ POP_SIZE = 3 # μ (親代數量)
 OFFSPRING_SIZE = POP_SIZE  # λ (後代數量)
 N_GENERATIONS = 100  # 總共要執行的世代數
 
+# 是否在評估函式中計算並回傳均勻度
+RETURN_UNIFORMITY = True
+
 # 基因範圍
 SIDE_BOUND = [0.4, 1.5]
 ANGLE_BOUND = [1, 179]
@@ -59,6 +62,7 @@ def write_run_config():
         "TAU_PRIME": TAU_PRIME,
         "TAU": TAU,
         "GLOBAL_SEED": GLOBAL_SEED,
+        "RETURN_UNIFORMITY": RETURN_UNIFORMITY,
         "save_root": save_root,
         "log_dir": log_dir,
     }
@@ -254,7 +258,9 @@ def simulate_and_evaluate(folder, individual):
     while True:
         try:
             tracepro_fast(os.path.join(folder, "Sim.scm"))
-            return evaluate_fitness(folder, individual, return_uniformity=True)
+            return evaluate_fitness(
+                folder, individual, return_uniformity=RETURN_UNIFORMITY
+            )
         except Exception as e:
             print(f"⚠️ tracepro/evaluate_fitness(parent {individual}) 失敗: {e}")
             time.sleep(1)
@@ -332,7 +338,9 @@ def main():
             folder = os.path.join(save_root, f"P{i+1}")
             if build_results[i]:
                 print(f"  評估初始模型 P{i+1}...")
-                eval_data = evaluate_fitness(folder, individual, return_uniformity=True)
+                eval_data = evaluate_fitness(
+                    folder, individual, return_uniformity=RETURN_UNIFORMITY
+                )
             else:
                 eval_data = (-999, 0, 0, 0.0, [], [0.0] * 8)  # 給予失敗個體極差的適應度
 
@@ -508,7 +516,9 @@ def main():
                 folder = os.path.join(save_root, f"P{i+1}")
                 print(f"  評估子代模型 P{i+1}...")
                 eval_data = evaluate_fitness(
-                    folder, children_genes[i], return_uniformity=False
+                    folder,
+                    children_genes[i],
+                    return_uniformity=RETURN_UNIFORMITY,
                 )
                 offspring_eval_data[i] = eval_data
                 log_row = create_log_row(

--- a/txt_new.py
+++ b/txt_new.py
@@ -70,12 +70,19 @@ def compute_regression_score(S1, S2, A1):
         0.004 * S1 * S2 * A1
     )
 
-def evaluate_fitness(folder, individual):
+def evaluate_fitness(folder, individual, return_uniformity=False):
+    """Evaluate fitness from simulation results in *folder* for the given
+    *individual* parameters.
+
+    When ``return_uniformity`` is ``True``, additional uniformity metrics are
+    computed and returned.
+    """
     S1, S2, A1 = individual
 
     weighted_efficiency_total = 0
     weight_sum = 0
     efficiencies_per_angle = []  # 新增儲存各角度效率
+    angle_unis = []
 
     weights = [1, 2, 5, 7, 5, 8.5, 1.5, 2]
 
@@ -89,6 +96,7 @@ def evaluate_fitness(folder, individual):
             total_energy = 0
             upward_energy = 0
 
+            angle_intensities = []
             for line in data_lines:
                 parts = line.strip().split()
                 if len(parts) < 2:
@@ -97,6 +105,7 @@ def evaluate_fitness(folder, individual):
                     polar_angle = float(parts[0])
                     intensity_col1 = float(parts[1])
                     total_energy += intensity_col1
+                    angle_intensities.append(intensity_col1)
                     if polar_angle > 90:
                         upward_energy += intensity_col1
                 except ValueError:
@@ -110,6 +119,14 @@ def evaluate_fitness(folder, individual):
             efficiencies_per_angle.append(eff)
             weighted_efficiency_total += eff * weights[idx]
             weight_sum += weights[idx]
+
+            if return_uniformity:
+                angle_intensities = np.array(angle_intensities)
+                if angle_intensities.mean() > 0:
+                    cv_a = angle_intensities.std() / angle_intensities.mean()
+                else:
+                    cv_a = 1.0
+                angle_unis.append(max(0.0, 1.0 - cv_a))
 
         except Exception as e:
             
@@ -131,6 +148,22 @@ def evaluate_fitness(folder, individual):
     w = 2
     fitness = efficiency * (1 / (1 + w * process_score))
 
-    return fitness, efficiency, process_score, efficiencies_per_angle
+    if return_uniformity:
+        uniformity = min(angle_unis) if angle_unis else 0.0
+        return (
+            fitness,
+            efficiency,
+            process_score,
+            uniformity,
+            efficiencies_per_angle,
+            angle_unis,
+        )
+    else:
+        return (
+            fitness,
+            efficiency,
+            process_score,
+            efficiencies_per_angle,
+        )
 
 


### PR DESCRIPTION
## Summary
- add `RETURN_UNIFORMITY` option to ES2 configuration
- write the flag to run configuration log
- update all calls to `evaluate_fitness` to use the flag
- extend `txt_new.evaluate_fitness` with optional uniformity calculations

## Testing
- `python -m py_compile ES2.py txt_new.py`

------
https://chatgpt.com/codex/tasks/task_e_68565f6014a88327acd918777cc1e496