### PR TITLE
Add Pareto front selection to ES2

### DIFF
--- a/ES2.py
+++ b/ES2.py
@@ -295,11 +295,9 @@ def pareto_sort(metrics, fitness_scores):
             fronts[0].append(p)
 
     i = 0
-    ranks = [0] * population_size
     while fronts[i]:
         next_front = []
         for p in fronts[i]:
-            ranks[p] = i
             for q in S[p]:
                 n_dom[q] -= 1
                 if n_dom[q] == 0:


### PR DESCRIPTION
## Summary
- implement `pareto_sort` to rank individuals by Pareto dominance
- select parents with multi-objective Pareto ranking

## Testing
- `python -m py_compile ES2.py`

------
https://chatgpt.com/codex/tasks/task_e_685f5d0664748327a27fd298e633f9fe