### PR TITLE
Fix relative import in compensation_models

### DIFF
--- a/printing/regression/compensation_models.py
+++ b/printing/regression/compensation_models.py
@@ -12,7 +12,10 @@ from sklearn.linear_model import HuberRegressor
 from sklearn.ensemble import RandomForestRegressor
 
 # 從工具模組導入共享的函式與變數
-from compensation_utils import FEATURES, TARGETS, augment_feats_for_lengths
+try:  # 優先使用套件內的相對匯入
+    from .compensation_utils import FEATURES, TARGETS, augment_feats_for_lengths
+except ImportError:  # pragma: no cover - 允許作為獨立腳本執行
+    from compensation_utils import FEATURES, TARGETS, augment_feats_for_lengths
 
 # ---------------- 長度模型 ----------------
 


### PR DESCRIPTION
## Summary
- use relative import for compensation utilities in regression models
- allow compensation_models.py to be run as a standalone script via absolute-import fallback

## Testing
- ⚠️ `python -m printing.regression.compensation_models` (missing pandas)
- ⚠️ `pip install pandas` (proxy blocked)
- ✅ `python - <<'PY' ...` (stubbed pandas and sklearn; module import and script run succeed)


------
https://chatgpt.com/codex/tasks/task_e_68b5a27ecdfc8327a3d529d2da8f1d05