### PR TITLE
Skip parent reevaluation after first generation

### DIFF
--- a/main/evolution.py
+++ b/main/evolution.py
@@ -487,7 +487,7 @@ async def main_async(args: argparse.Namespace):
     utils.set_output_dir(output_dir)
     os.makedirs(config.LOG_DIR, exist_ok=True)
 
-    start_gen, pop_genes, pop_sigmas, _, _ = utils.resume_from_log()
+    start_gen, pop_genes, pop_sigmas, prev_parent_eval, _ = utils.resume_from_log()
 
     if start_gen == 1:
         pop_genes = np.random.rand(config.POP_SIZE, config.N_VARS)
@@ -512,35 +512,43 @@ async def main_async(args: argparse.Namespace):
         print(f"\n--- 第 {gen}/{config.N_GENERATIONS} 代 ---")
 
         # 1. 評估父代，並只保留成功的個體
-        parent_eval = []
-        successful_parent_genes = np.array([])
-        successful_parent_sigmas = np.array([])
+        if prev_parent_eval is not None:
+            print("跳過父代評估，直接沿用上一代結果。")
+            parent_eval = prev_parent_eval
+            successful_parent_genes = pop_genes
+            successful_parent_sigmas = pop_sigmas
+        else:
+            parent_eval = []
+            successful_parent_genes = np.array([])
+            successful_parent_sigmas = np.array([])
 
-        with ThreadPoolExecutor(max_workers=config.MAX_WORKERS) as executor:
-            future_to_idx = {
-                executor.submit(
-                    evaluate_individual,
-                    (i + 1, pop_genes[i], pop_sigmas[i], "parent_old"),
-                    gen,
-                    (-1, -1),
-                ): i
-                for i in range(len(pop_genes))
-            }
+            with ThreadPoolExecutor(max_workers=config.MAX_WORKERS) as executor:
+                future_to_idx = {
+                    executor.submit(
+                        evaluate_individual,
+                        (i + 1, pop_genes[i], pop_sigmas[i], "parent_old"),
+                        gen,
+                        (-1, -1),
+                    ): i
+                    for i in range(len(pop_genes))
+                }
 
-            eval_map = {}
-            for future in future_to_idx:
-                try:
-                    result = future.result()
-                    if result:
-                        eval_map[future_to_idx[future]] = result
-                except Exception as exc:
-                    print(f"個體評估產生例外: {exc}")
+                eval_map = {}
+                for future in future_to_idx:
+                    try:
+                        result = future.result()
+                        if result:
+                            eval_map[future_to_idx[future]] = result
+                    except Exception as exc:
+                        print(f"個體評估產生例外: {exc}")
 
-            successful_indices = sorted(eval_map.keys())
-            if successful_indices:
-                parent_eval = [eval_map[i] for i in successful_indices]
-                successful_parent_genes = pop_genes[successful_indices]
-                successful_parent_sigmas = pop_sigmas[successful_indices]
+                successful_indices = sorted(eval_map.keys())
+                if successful_indices:
+                    parent_eval = [eval_map[i] for i in successful_indices]
+                    successful_parent_genes = pop_genes[successful_indices]
+                    successful_parent_sigmas = pop_sigmas[successful_indices]
+
+        prev_parent_eval = None
 
         if len(successful_parent_genes) == 0:
             print(f"❌ 第 {gen} 代所有父代均評估失敗，無法產生子代。演化終止。")
@@ -675,6 +683,7 @@ async def main_async(args: argparse.Namespace):
         # 更新族群以進行下一代
         pop_genes = next_pop_genes
         pop_sigmas = next_pop_sigmas
+        prev_parent_eval = next_pop_eval
 
         gc.collect()
 

--- a/main/utils.py
+++ b/main/utils.py
@@ -144,10 +144,10 @@ def resume_from_log():
         os.makedirs(log_dir, exist_ok=True)
         log_files = [f for f in os.listdir(log_dir) if f.startswith("fitness_gen")]
     except FileNotFoundError:
-        return 1, None, None, [], []
+        return 1, None, None, None, []
 
     if not log_files:
-        return 1, None, None, [], []
+        return 1, None, None, None, []
 
     latest_gen_num = 0
     latest_file = ""
@@ -158,7 +158,7 @@ def resume_from_log():
             latest_file = f
 
     if not latest_file:
-        return 1, None, None, [], []
+        return 1, None, None, None, []
 
     latest_filepath = os.path.join(log_dir, latest_file)
     try:
@@ -173,7 +173,7 @@ def resume_from_log():
             gene_columns = ["S2", "S3", "A3"]
         elif not all(col in df.columns for col in gene_columns):
             print(f"⚠️ 日誌檔案 '{latest_file}' 缺少必要的基因欄位。將從頭開始。")
-            return 1, None, None, [], []
+            return 1, None, None, None, []
 
         if is_complete:
             print(
@@ -187,7 +187,18 @@ def resume_from_log():
                 dtype=float
             )
 
-            return start_gen, pop_genes, pop_sigmas, [], []
+            parent_eval = [
+                (
+                    safe_float(r["fitness"]),
+                    safe_float(r["efficiency"]),
+                    safe_float(r["process_score"]),
+                    {},
+                    0.0,
+                )
+                for _, r in final_parents.iterrows()
+            ]
+
+            return start_gen, pop_genes, pop_sigmas, parent_eval, []
         else:
             # 簡化恢復邏輯：如果世代未完成，則從該世代的初始父代重新開始
             print(f"🔁 偵測到未完成的第 {latest_gen_num} 代，將從此代重新開始評估。")
@@ -198,19 +209,19 @@ def resume_from_log():
                 print(
                     f"⚠️ 第 {start_gen} 代日誌損毀 (找不到 'parent_old' 資訊)，將從頭開始。"
                 )
-                return 1, None, None, [], []
+                return 1, None, None, None, []
 
             pop_genes = parent_old_df[gene_columns].to_numpy(dtype=float)
             pop_sigmas = parent_old_df[["sigma1", "sigma2", "sigma3"]].to_numpy(
                 dtype=float
             )
 
-            # 返回空列表，觸發對該世代的重新評估
-            return start_gen, pop_genes, pop_sigmas, [], []
+            # 返回 None，觸發對該世代的重新評估
+            return start_gen, pop_genes, pop_sigmas, None, []
 
     except Exception as e:
         print(f"❌ 讀取日誌檔案 '{latest_filepath}' 時發生錯誤: {e}。將從頭開始。")
-        return 1, None, None, [], []
+        return 1, None, None, None, []
 
 
 def send_error(subject, body=""):


### PR DESCRIPTION
## Summary
- Reuse previous generation evaluations to skip redundant parent reevaluation starting from generation 2
- Allow resuming logic to return stored parent fitness data for reuse

## Testing
- `python -m py_compile main/utils.py main/evolution.py`


------
https://chatgpt.com/codex/tasks/task_e_68bed02604548327915b54e16100a126