### PR TITLE
Add retry mechanism for failed simulations

### DIFF
--- a/main/config.py
+++ b/main/config.py
@@ -24,6 +24,10 @@ DIVERSITY_PENALTY_FACTOR = 0.15
 # === 並行處理設定 ===
 MAX_WORKERS = os.cpu_count() or 4
 
+# === 模擬錯誤重試設定 ===
+# 當 AutoCAD 或 TracePro 模擬失敗時的最大重試次數
+SIM_MAX_RETRIES = 3
+
 # === 模型設定 ===
 MODEL_TYPE = "Huber"
 ADD_RATIOS = False

--- a/main/evolution.py
+++ b/main/evolution.py
@@ -359,19 +359,32 @@ def evaluate_individual(individual_data, generation, parent_indices):
         "predicted_a3": sim_design["Design_a3(deg)"],
     }
 
-    sim_result = run_simulation(
-        sim_design["Design_s1(mm)"],
-        sim_design["Design_s2(mm)"],
-        sim_design["Design_s3(mm)"],
-        sim_design["Design_a1(deg)"],
-        sim_design["Design_a2(deg)"],
-        sim_design["Design_a3(deg)"],
-        loop_num,
-        individual,
-    )
+    # --- 模擬執行與重試機制 ---
+    sim_result = None
+    attempt = 0
+    while sim_result is None:
+        attempt += 1
+        sim_result = run_simulation(
+            sim_design["Design_s1(mm)"],
+            sim_design["Design_s2(mm)"],
+            sim_design["Design_s3(mm)"],
+            sim_design["Design_a1(deg)"],
+            sim_design["Design_a2(deg)"],
+            sim_design["Design_a3(deg)"],
+            loop_num,
+            individual,
+        )
 
-    if sim_result is None:
-        return None
+        if sim_result is None:
+            if attempt >= config.SIM_MAX_RETRIES:
+                print(
+                    f"❌ Simulation for individual P{loop_num} failed after {attempt} attempts. Skipping this individual."
+                )
+                return None
+            print(
+                f"⚠️ Simulation for individual P{loop_num} failed on attempt {attempt}. Retrying..."
+            )
+            time.sleep(1)
 
     fitness, efficiency, process_score, angle_eff_list = (
         sim_result[0],


### PR DESCRIPTION
## Summary
- add `SIM_MAX_RETRIES` config to control how many times a failed simulation should be retried
- wrap simulation execution with retry loop so failed TracePro runs are retried before moving on

## Testing
- `python -m py_compile main/evolution.py main/config.py`


------
https://chatgpt.com/codex/tasks/task_e_68bedd10293883279fba23c250828ec8